### PR TITLE
Add custom csid conf option

### DIFF
--- a/README
+++ b/README
@@ -50,6 +50,11 @@ by forcing re-authentication every hour.
 message is generated ONLY when a user has authenticated, and their
 name & file accessed is put in the log file.
 
+  The per-dir AddRadiusCallingStationID configuration option will
+force the calling station ID string (only static strings) and
+include it in authentication requests, if used. If not used, the
+default behavior, using the client's remote IP address will be
+applied.
 
   How it works
   ============
@@ -179,6 +184,23 @@ RFCs properly.
 
   Any questions or comments can be sent to me at: aland@freeradius.org
 
+  Fork
+  ====
+
+  This fork simply adds a setting for Apache 2.x, allowing to specify
+a custom Calling Station ID string, that is not necessarily the client's
+IP address.
+
+  This is a behiavor I needed in order to accomodate an historic
+implementation at my company that used the Calling Station ID as a
+group membership indicator/security token, prompting me to create
+my own patch, in a non-disruptive fashion compared to the existing
+implementation and behavior. ("Don't add it, nothing changes")
+
+  In a way, in my specific use case, AddRadiusCallingStationID is
+used in the same way as one would use "require group" with mod_ldap.
+
 --
 Author:  Alan DeKok <aland@freeradius.org>
+Patch:   Stephane Lapie <stephane.lapie@asahinet.com>
          $Id$

--- a/httpd.conf
+++ b/httpd.conf
@@ -140,6 +140,12 @@ AuthRadiusActive On
 require valid-user
 
 #
+# Force the calling station ID to 'MyServiceName' for location /secure/
+# AddRadiusCallingStationID <string 1..255 bytes>
+#
+AddRadiusCallingStationID MyServiceName
+
+#
 # end of the per-location directives
 #
 </Location>


### PR DESCRIPTION
I stumbled upon a case where I needed to authenticate against a custom RADIUS server (using the Calling Station ID attribute as a security token, something close in this instance to a group name, to ensure a user both has valid credentials AND proper authorization to access the protected service), and where the default behavior of sending the client's remote IP was not what I wanted.

Therefore I created a patch to add a configuration option to define a different CSID per-directory. Behavior is unchanged from the original implementation, as long as AddRadiusCallingStationID is not used.

My purpose here is to make mod_auth_radius more flexible and usable even with oddball implementations, while not impairing standard use cases.

Note : The "empty string" case does not have any special handling whatsoever, but I am considering about further making it so that if the option is specified with an empty string, then it would be understood as really wanting to remove the Calling Station ID attribute, and have mod_auth_radius not include it in user_login(), but I wonder if this is appropriate.
