### PR TITLE
Display git revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,15 @@ MOD_RADIUS_MINOR_VERSION = $(shell cat VERSION | cut -f2 -d.)
 MOD_RADIUS_INCRM_VERSION = $(shell cat VERSION | cut -f3 -d.)
 MOD_RADIUS_VERSION = $(MOD_RADIUS_MAJOR_VERSION).$(MOD_RADIUS_MINOR_VERSION).$(MOD_RADIUS_INCRM_VERSION)
 
+GIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+GIT_COMMIT = $(shell git log --pretty=format:'%h' -n 1)
+
+ifneq ($(GIT_COMMIT), '')
+MOD_RADIUS_VERSION_STRING = $(MOD_RADIUS_VERSION)-git-$(GIT_COMMIT)
+else
+MOD_RADIUS_VERSION_STRING = $(MOD_RADIUS_VERSION)
+endif
+
 ######################################################################
 #
 #  The default rule: tell the user what to REALLY do to use
@@ -23,7 +32,7 @@ MOD_RADIUS_VERSION = $(MOD_RADIUS_MAJOR_VERSION).$(MOD_RADIUS_MINOR_VERSION).$(M
 
 ifeq ($(which apxs), '')
 all:
-	@echo Can't find apxs, assuming this module will be built with apache
+	@echo Can\'t find apxs, assuming this module will be built with apache
 	@echo
 	@echo Configure this module into Apache by going to the Apache root directory,
 	@echo and typing:
@@ -45,9 +54,11 @@ all:
 	@echo You should add your additional site configuration options to the 'configure'
 	@echo line, above.  Please read the README file for further information.
 	@echo
+
 install:
 	@$(MAKE)
 else
+
 all: mod_auth_radius.o
 
 .PHONY: install
@@ -56,7 +67,7 @@ install:
 endif
 
 mod_auth_radius.o: mod_auth_radius.c
-	@apxs -Wall -DMOD_RADIUS_AUTH_VERSION_STRING='\"$(MOD_RADIUS_VERSION)\"' -c $<
+	@apxs -Wall -DMOD_RADIUS_AUTH_VERSION_STRING='\"$(MOD_RADIUS_VERSION_STRING)\"' -c $<
 
 ######################################################################
 #

--- a/mod_auth_radius.c
+++ b/mod_auth_radius.c
@@ -1197,7 +1197,7 @@ static int radius_hook_init(apr_pool_t *pconf,
                             apr_pool_t *mp_log,
                             apr_pool_t *mp_temp,
                             server_rec *s) {
-	char package[32];
+	char package[48]; /* e.g: mod_auth_radius/<version>[-git-<crc>] */
 
 	/* Setup module version information. */
 #ifdef MOD_RADIUS_AUTH_VERSION_STRING


### PR DESCRIPTION
Some evidences

```
[jpereira@jpereira-desktop mod_auth_radius.git]$ make
/usr/share/apr-1.0/build/libtool --silent --mode=compile --tag=disable-static x86_64-linux-gnu-gcc -std=gnu99 -prefer-pic -pipe -g -O2 -fstack-protector-strong -Wformat -Werror=format-security  -D_FORTIFY_SOURCE=2   -DLINUX -D_REENTRANT -D_GNU_SOURCE  -pthread  -I/usr/include/apache2  -I/usr/include/apr-1.0   -I/usr/include/apr-1.0 -I/usr/include -DMOD_RADIUS_AUTH_VERSION_STRING=\"1.6.1-git-ed0a23c\"  -c -o mod_auth_radius.lo mod_auth_radius.c && touch mod_auth_radius.slo
/usr/share/apr-1.0/build/libtool --silent --mode=link --tag=disable-static x86_64-linux-gnu-gcc -std=gnu99 -Wl,--as-needed -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now    -o mod_auth_radius.la  -rpath /usr/lib/apache2/modules -module -avoid-version    mod_auth_radius.lo
[jpereira@jpereira-desktop mod_auth_radius.git]$ sudo make install
/usr/share/apache2/build/instdso.sh SH_LIBTOOL='/usr/share/apr-1.0/build/libtool' mod_auth_radius.la /usr/lib/apache2/modules
/usr/share/apr-1.0/build/libtool --mode=install install mod_auth_radius.la /usr/lib/apache2/modules/
libtool: install: install .libs/mod_auth_radius.so /usr/lib/apache2/modules/mod_auth_radius.so
libtool: install: install .libs/mod_auth_radius.lai /usr/lib/apache2/modules/mod_auth_radius.la
libtool: finish: PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin" ldconfig -n /usr/lib/apache2/modules
----------------------------------------------------------------------
Libraries have been installed in:
   /usr/lib/apache2/modules

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the `-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the `LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the `LD_RUN_PATH' environment variable
     during linking
   - use the `-Wl,-rpath -Wl,LIBDIR' linker flag
   - have your system administrator add LIBDIR to `/etc/ld.so.conf'

See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
----------------------------------------------------------------------
chmod 644 /usr/lib/apache2/modules/mod_auth_radius.so
[preparing module `radius_auth' in /etc/apache2/mods-available/radius_auth.load]
Module radius_auth already enabled
[jpereira@jpereira-desktop mod_auth_radius.git]$ sudo /etc/init.d/apache2 restart
[ ok ] Restarting apache2 (via systemctl): apache2.service.
[jpereira@jpereira-desktop mod_auth_radius.git]$ 
```

Showing the version
```
[jpereira@jpereira-desktop mod_auth_radius.git]$ curl -v http://localhost/ 2>&1 | grep Server:
< Server: Apache/2.4.12 (Ubuntu) mod_auth_radius/1.6.1-git-ed0a2 mod_wsgi/4.3.0 Python/2.7.10
[jpereira@jpereira-desktop mod_auth_radius.git]$
```
