### PR TITLE
Always add WWW-Authenticate header when auth fails

### DIFF
--- a/mod_auth_radius.c
+++ b/mod_auth_radius.c
@@ -1007,6 +1007,8 @@ void challenge_auth_failure(request_rec *r,
 {
 	if (!*message) { /* no message to print */
 		/* note_basic_auth_failure(r); */
+		apr_table_set(r->err_headers_out, "WWW-Authenticate",
+                              apr_psprintf(r->pool, "Basic realm=\"%s\"", ap_auth_name(r)));
 	} else {            /* print our magic message */
 		apr_table_set(r->err_headers_out, "WWW-Authenticate",
 			      apr_pstrcat(r->pool, "Basic realm=\"", ap_auth_name(r), " for ", user, " '", message, "'",


### PR DESCRIPTION
This is required so the user agent can determine what auth
method is supported.

Quote from RFC 2617:
If the origin server does not wish to accept the credentials sent
with a request, it SHOULD return a 401 (Unauthorized) response. The
response MUST include a WWW-Authenticate header field containing at
least one (possibly new) challenge applicable to the requested
resource.

Reported-By: Süleyman Kuran <skuran@ayk.gov.tr>